### PR TITLE
added editUser mutation into resolvers.js and typeDefs.js

### DIFF
--- a/Develop/server/schemas/resolvers.js
+++ b/Develop/server/schemas/resolvers.js
@@ -63,6 +63,16 @@ const resolvers = {
       const token = signToken(user);
       return { token, user };
     },
+    editUser: async (_, { university, major, year }, { user }) => {
+      if (!user) {
+        throw AuthenticationError;
+      }
+      return await User.findByIdAndUpdate(user._id, {
+        university,
+        major,
+        year
+      }, { new: true });
+    },
     removeUser: async (parent, { userId }) => {
       const user = await User.findById(userId);
       if (!user) {

--- a/Develop/server/schemas/typeDefs.js
+++ b/Develop/server/schemas/typeDefs.js
@@ -36,6 +36,7 @@ const typeDefs = `
   type Mutation {
     login(email: String!, password: String!): Auth
     addUser(username: String!, email: String!, password: String!, firstName: String, lastName: String, university: String, major: String, year: Int): Auth
+    editUser(university: String, major: String, year: Int): User
     removeUser(userId: ID!): User
     addGroup(name: String!, subject: String, description: String): Group
     joinGroup(userId: ID!, groupId: ID!): User


### PR DESCRIPTION
Tested in Apollo Playground after running addUser and login mutations and then passing the token in the header. It works as intended and allows for edits to the university, major, and year fields of the currently logged in user.